### PR TITLE
Adjust Policy Softmax Temperature to 0.95 (#85)

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -62,7 +62,8 @@ impl SearchHelpers {
     pub fn get_pst(q: f32, params: &MctsParams) -> f32 {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
-        1.0 + (params.winning_pst_max() - 1.0) * t
+        1.0 + params.base_pst_adjustment()
+            + (params.winning_pst_max() - (1.0 + params.base_pst_adjustment())) * t
     }
 
     /// First Play Urgency

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -131,9 +131,10 @@ macro_rules! make_mcts_params {
 
 make_mcts_params! {
     root_pst: f32 = 3.102, 1.0, 10.0, 0.4, 0.002;
-    depth_2_pst: f32 = 1.23, 1.0, 10.0, 0.4, 0.002;
+    depth_2_pst_adjustment: f32 = 0.23, 1.0, 10.0, 0.025, 0.002;
     winning_pst_threshold: f32 = 0.603, 0.0, 1.0, 0.05, 0.002;
-    winning_pst_max: f32 = 1.615, 0.1, 10.0, 0.4, 0.002;
+    winning_pst_max: f32 = 1.615, 0.1, 10.0, 0.1, 0.002;
+    base_pst_adjustment: f32 = -0.05, 0.1, 10.0, 0.005, 0.002;
     root_cpuct: f32 = 0.422, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.269, 0.1, 5.0, 0.065, 0.002;
     cpuct_var_weight: f32 = 0.808, 0.0, 2.0, 0.085, 0.002;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -184,7 +184,7 @@ impl Tree {
         let pst = match depth {
             0 => unreachable!(),
             1 => params.root_pst(),
-            2 => params.depth_2_pst(),
+            2 => 1.0 + params.depth_2_pst_adjustment(),
             3.. => SearchHelpers::get_pst(self[node_ptr].q(), params),
         };
 
@@ -241,7 +241,7 @@ impl Tree {
         let pst = match depth {
             0 => unreachable!(),
             1 => params.root_pst(),
-            2 => params.depth_2_pst(),
+            2 => 1.0 + params.depth_2_pst_adjustment(),
             3.. => unreachable!(),
         };
 


### PR DESCRIPTION
Changes policy softmax temperature of all the nodes beyond depth 2 to 0.95. Modifications to temperature based on the q also use this 0.95 as the base.

STC
LLR: 3.01 (-2.94,2.94) <0.00,4.00>
Total: 37120 W: 9534 L: 9242 D: 18344
Ptnml(0-2): 610, 4365, 8388, 4517, 680
https://tests.montychess.org/tests/view/675e2a591678cfe6b825afd1

LTC
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 27852 W: 6123 L: 5861 D: 15868
Ptnml(0-2): 169, 3100, 7108, 3398, 151
https://tests.montychess.org/tests/view/675ed3191678cfe6b825d04e

Bench: 2004833